### PR TITLE
test: add since filter test for get_signals

### DIFF
--- a/tests/signals.test.ts
+++ b/tests/signals.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb, seedTeam, seedOpenIntent } from './setup.js';
+import { setupTestDb, cleanTestDb, teardownTestDb, seedTeam, seedOpenIntent, testQuery } from './setup.js';
 import * as db from '../src/db/queries.js';
 
 describe('Signals', () => {
@@ -59,6 +59,28 @@ describe('Signals', () => {
     const backendSignals = await db.getSignals({ team_id: 'backend' });
     expect(backendSignals).toHaveLength(1);
     expect(backendSignals[0].message).toBe('Backend signal');
+  });
+
+  it('filters signals by since timestamp', async () => {
+    const intent = await seedOpenIntent();
+
+    // Insert a signal timestamped 1 hour ago
+    await testQuery(
+      `INSERT INTO signals (type, from_user, intent_id, message, created_at)
+       VALUES ('info', 'pawel', $1, 'Old signal', now() - interval '1 hour')`,
+      [intent.id]
+    );
+
+    // Capture "since" from the DB clock so it falls between old and new signals
+    const sinceRes = await testQuery('SELECT now()::text AS now');
+    const since = sinceRes.rows[0].now;
+
+    await db.sendSignal({ type: 'info', from_user: 'alice', intent_id: intent.id as string, message: 'New signal' });
+
+    const recent = await db.getSignals({ since });
+    expect(recent).toHaveLength(1);
+    expect(recent[0].message).toBe('New signal');
+    expect(recent[0].from_user).toBe('alice');
   });
 
   it('respects limit parameter', async () => {


### PR DESCRIPTION
## Summary

- Adds integration test for the `since` parameter in `getSignals`, which was functional but untested
- Uses `testQuery` with explicit past timestamps for deterministic results (no timing dependencies)
- All 68 tests pass against real PostgreSQL

From the suggested first contributions in CONTRIBUTING.md:
> Add a `since` filter test for `get_signals`

## Test plan

- [x] `npm test` — 68/68 passing
- [x] No mocks, integration test against real PostgreSQL
- [x] Follows existing test patterns in `signals.test.ts`