### PR TITLE
fix: improve error messages in claimWork and heartbeat

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -257,7 +257,17 @@ export async function claimWork(params: ClaimWorkParams): Promise<{ claim: Claim
   const intentRes = await query<Intent>(`SELECT * FROM intents WHERE id = $1`, [params.intent_id]);
   const intent = intentRes.rows[0];
   if (!intent) throw new Error(`Intent ${params.intent_id} not found`);
-  if (intent.status !== 'open') throw new Error(`Intent ${params.intent_id} is not open (current: ${intent.status})`);
+  if (intent.status !== 'open') {
+    if (intent.status === 'claimed') {
+      const activeClaim = await query<Claim>(
+        `SELECT claimed_by FROM claims WHERE intent_id = $1 AND status = 'active' LIMIT 1`,
+        [params.intent_id]
+      );
+      const claimedBy = activeClaim.rows[0]?.claimed_by;
+      throw new Error(`Intent ${params.intent_id} is already claimed by ${claimedBy ?? 'unknown'}`);
+    }
+    throw new Error(`Intent ${params.intent_id} is not open (current: ${intent.status})`);
+  }
 
   // Create the claim
   const claimRes = await query<Claim>(
@@ -299,7 +309,11 @@ export async function heartbeat(claimId: string, filesTouching?: string[]): Prom
     `UPDATE claims SET ${sets.join(', ')} WHERE id = $${paramIdx} AND status = 'active' RETURNING *`,
     [...values, claimId]
   );
-  if (res.rows.length === 0) throw new Error(`Active claim ${claimId} not found`);
+  if (res.rows.length === 0) {
+    const existing = await query<Claim>(`SELECT status FROM claims WHERE id = $1`, [claimId]);
+    if (existing.rows.length === 0) throw new Error(`Claim ${claimId} not found`);
+    throw new Error(`Claim ${claimId} is not active (current: ${existing.rows[0].status})`);
+  }
   return res.rows[0];
 }
 

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -62,13 +62,13 @@ describe('Edge Cases & Error Paths', () => {
     ).rejects.toThrow('not found');
   });
 
-  it('claim rejects already-claimed intent', async () => {
+  it('claim rejects already-claimed intent with claimer info', async () => {
     const intent = await seedOpenIntent();
     await db.claimWork({ intent_id: intent.id as string, claimed_by: 'pawel' });
 
     await expect(
       db.claimWork({ intent_id: intent.id as string, claimed_by: 'alice' })
-    ).rejects.toThrow('not open');
+    ).rejects.toThrow('claimed by pawel');
   });
 
   it('claim rejects done intent', async () => {
@@ -90,7 +90,7 @@ describe('Edge Cases & Error Paths', () => {
     const { claim } = await db.claimWork({ intent_id: intent.id as string, claimed_by: 'pawel' });
     await db.completeClaim(claim.id);
 
-    await expect(db.completeClaim(claim.id)).rejects.toThrow('not active');
+    await expect(db.completeClaim(claim.id)).rejects.toThrow('completed');
   });
 
   it('complete rejects abandoned claim', async () => {
@@ -98,7 +98,7 @@ describe('Edge Cases & Error Paths', () => {
     const { claim } = await db.claimWork({ intent_id: intent.id as string, claimed_by: 'pawel' });
     await db.releaseClaim(claim.id);
 
-    await expect(db.completeClaim(claim.id)).rejects.toThrow('not active');
+    await expect(db.completeClaim(claim.id)).rejects.toThrow('abandoned');
   });
 
   it('release rejects non-existent claim', async () => {
@@ -109,12 +109,12 @@ describe('Edge Cases & Error Paths', () => {
     await expect(db.heartbeat('claim_nonexistent')).rejects.toThrow('not found');
   });
 
-  it('heartbeat rejects completed claim', async () => {
+  it('heartbeat rejects completed claim with status', async () => {
     const intent = await seedOpenIntent();
     const { claim } = await db.claimWork({ intent_id: intent.id as string, claimed_by: 'pawel' });
     await db.completeClaim(claim.id);
 
-    await expect(db.heartbeat(claim.id)).rejects.toThrow('not found');
+    await expect(db.heartbeat(claim.id)).rejects.toThrow('completed');
   });
 
   // ─── Conflict Edge Cases ────────────────────────


### PR DESCRIPTION
## Summary

From the suggested first contributions:
> Improve error messages in query functions

- **`claimWork`** — when an intent is already claimed, the error now includes who claimed it (`"already claimed by pawel"`) instead of the generic `"not open (current: claimed)"`. Helps an agent decide whether to wait, coordinate, or pick different work.
- **`heartbeat`** — now distinguishes between a non-existent claim (`"not found"`) and a non-active claim (`"not active (current: completed)"`). Previously both cases returned `"Active claim X not found"`.

No changes to happy paths. Extra queries only run on error paths.

**Note:** Also tightened two existing `completeClaim` test assertions from `'not active'` to `'completed'`/`'abandoned'` for specificity — the `completeClaim` code itself was not changed. Renamed two test cases to reflect the new assertions.

## Test plan

- [x] `npm test` — 68/68 passing against real PostgreSQL
- [x] No mocks, integration tests only
- [x] Follows existing patterns in `queries.ts` and `edge-cases.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)